### PR TITLE
Added namesOnly option

### DIFF
--- a/src/classes/options.ts
+++ b/src/classes/options.ts
@@ -1,0 +1,20 @@
+/**
+ * Class with options passed to getDiskInfo
+ * @author Ivo Valls
+ */
+export default class DiskInfoOptions {
+
+    /**
+     * If set to true only the names will be retrieved
+     */
+    private readonly _namesOnly: boolean;
+
+    public constructor(namesOnly?: boolean) {
+        this._namesOnly = namesOnly ?? false;
+    }
+
+
+    public get namesOnly(): boolean {
+        return this._namesOnly;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 import Drive from './classes/drive';
-import {Darwin} from './platforms/darwin';
-import {Linux} from './platforms/linux';
-import {Windows} from './platforms/windows';
-import {Utils} from './utils/utils';
+import { Darwin } from './platforms/darwin';
+import { Linux } from './platforms/linux';
+import { Windows } from './platforms/windows';
+import { Utils } from './utils/utils';
 
+import DiskInfoOptions from './classes/options';
 /**
  * Get disk info according current platform.
  *
  * @author Cristiam Mercado
  * @return {Promise<Drive[]>} Promise resolves array of disks and their info.
  */
-export function getDiskInfo(): Promise<Drive[]> {
+export function getDiskInfo(options: DiskInfoOptions = new DiskInfoOptions()): Promise<Drive[]> {
 
     return new Promise((resolve, reject) => {
 
@@ -27,28 +28,28 @@ export function getDiskInfo(): Promise<Drive[]> {
                     reject(new Error(`Platform not supported: ${platform}`));
                     break;
                 case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-                    drivesInfo = Darwin.run();
+                    drivesInfo = Darwin.run(options);
                     resolve(drivesInfo);
                     break;
                 case 'freebsd': // FreeBSD Platform
-                    drivesInfo = Darwin.run();
+                    drivesInfo = Darwin.run(options);
                     resolve(drivesInfo);
                     break;
                 case 'linux': // Linux Platform
-                    drivesInfo = Linux.run();
+                    drivesInfo = Linux.run(options);
                     resolve(drivesInfo);
                     break;
                 case 'openbsd': // OpenBSD platform
-                    drivesInfo = Darwin.run();
+                    drivesInfo = Darwin.run(options);
                     resolve(drivesInfo);
                     break;
                 case 'sunos': // SunOS platform
                     reject(new Error(`Platform not supported: ${platform}`));
                     break;
                 case 'win32': // windows platform
-                    drivesInfo = Windows.run();
+                    drivesInfo = Windows.run(options);
                     resolve(drivesInfo);
-                    break;    
+                    break;
                 default: // unknown platform
                     reject(new Error(`Platform not recognized: ${platform}`));
             }
@@ -68,8 +69,8 @@ export function getDiskInfo(): Promise<Drive[]> {
  * @return {Drive[]} Array of disks and their info.
  * @throws {Error} Current platform must be win32, linux or darwin.
  */
-export function getDiskInfoSync(): Drive[] {
-
+export function getDiskInfoSync(options: DiskInfoOptions = new DiskInfoOptions()): Drive[] {
+    if (options == void 0) { options = new DiskInfoOptions() }
     const platform = Utils.detectPlatform();
     let drivesInfo: Drive[];
 
@@ -79,21 +80,21 @@ export function getDiskInfoSync(): Drive[] {
         case 'android': // Android platform
             throw new Error("Platform not supported: " + platform);
         case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-            drivesInfo = Darwin.run();
+            drivesInfo = Darwin.run(options);
             return drivesInfo;
         case 'freebsd': // FreeBSD Platform
-            drivesInfo = Darwin.run();
+            drivesInfo = Darwin.run(options);
             return drivesInfo;
         case 'linux': // Linux Platform
-            drivesInfo = Linux.run();
+            drivesInfo = Linux.run(options);
             return drivesInfo;
         case 'openbsd': // OpenBSD platform
-            drivesInfo = Darwin.run();
+            drivesInfo = Darwin.run(options);
             return drivesInfo;
         case 'sunos': // SunOS platform
             throw new Error("Platform not supported: " + platform);
         case 'win32': // windows platform
-            drivesInfo = Windows.run();
+            drivesInfo = Windows.run(options);
             return drivesInfo;
         default: // unknown platform
             throw new Error("Platform not recognized: " + platform);

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -1,7 +1,8 @@
-import {Constants} from '../utils/constants';
+import { Constants } from '../utils/constants';
 
 import Drive from '../classes/drive';
-import {Utils} from "../utils/utils";
+import DiskInfoOptions from '../classes/options';
+import { Utils } from "../utils/utils";
 
 /**
  * Class with OSX specific logic to get disk info.
@@ -13,10 +14,11 @@ export class Darwin {
      *
      * @return {Drive[]} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static run(options: DiskInfoOptions): Drive[] {
 
         const drives: Drive[] = [];
-        const buffer = Utils.execute(Constants.DARWIN_COMMAND);
+        const command = options.namesOnly ? Constants.DARWIN_COMMAND_NAMES_ONLY : Constants.DARWIN_COMMAND;
+        const buffer = Utils.execute(command);
         const lines = buffer.toString().split('\n');
 
         lines.forEach((value, index, array) => {

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -1,7 +1,8 @@
-import {Constants} from '../utils/constants';
+import { Constants } from '../utils/constants';
 
 import Drive from '../classes/drive';
-import {Utils} from "../utils/utils";
+import DiskInfoOptions from '../classes/options';
+import { Utils } from "../utils/utils";
 
 /**
  * Class with Linux specific logic to get disk info.
@@ -13,10 +14,11 @@ export class Linux {
      *
      * @return {Drive[]} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static run(options: DiskInfoOptions): Drive[] {
 
         const drives: Drive[] = [];
-        const buffer = Utils.execute(Constants.LINUX_COMMAND);
+        const command = options.namesOnly ? Constants.LINUX_COMMAND_NAMES_ONLY : Constants.LINUX_COMMAND;
+        const buffer = Utils.execute(command);
         const lines = buffer.toString().split('\n');
 
         lines.forEach((value) => {

--- a/src/platforms/windows.ts
+++ b/src/platforms/windows.ts
@@ -1,7 +1,8 @@
-import {Constants} from '../utils/constants';
+import { Constants } from '../utils/constants';
 
 import Drive from '../classes/drive';
-import {Utils} from "../utils/utils";
+import DiskInfoOptions from '../classes/options';
+import { Utils } from "../utils/utils";
 import iconv from 'iconv-lite';
 
 /**
@@ -14,11 +15,13 @@ export class Windows {
      *
      * @return {Drive[]} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static run(options: DiskInfoOptions): Drive[] {
 
         const drives: Drive[] = [];
-        let buffer = Utils.execute(Constants.WINDOWS_COMMAND);
-        
+        const command = options.namesOnly ? Constants.WINDOWS_COMMAND_NAMES_ONLY : Constants.WINDOWS_COMMAND;
+
+        let buffer = Utils.execute(command);
+
         const cp = Utils.chcp();
         let encoding = '';
         switch (cp) {
@@ -27,7 +30,7 @@ export class Windows {
                 break;
             case '65001': // UTF-8
                 encoding = 'UTF-8';
-                break;   
+                break;
             default: // Other Encoding
                 if (/^-?[\d.]+(?:e-?\d+)?$/.test(cp)) {
                     encoding = 'cp' + cp;
@@ -35,7 +38,7 @@ export class Windows {
                     encoding = cp;
                 }
         }
-        buffer = iconv.encode(iconv.decode(buffer, encoding),'UTF-8');
+        buffer = iconv.encode(iconv.decode(buffer, encoding), 'UTF-8');
 
         const lines = buffer.toString().split('\r\r\n');
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,13 +9,28 @@ export class Constants {
     public static readonly WINDOWS_COMMAND: string = 'wmic logicaldisk get Caption,FreeSpace,Size,VolumeSerialNumber,Description  /format:list';
 
     /**
+     *  Command to execute on Windows if only the names are needed.
+     */
+    public static readonly WINDOWS_COMMAND_NAMES_ONLY: string = 'wmic logicaldisk get Caption  /format:list';
+
+    /**
      * Command to execute on Linux.
      */
     public static readonly LINUX_COMMAND: string = 'df -P | awk \'NR > 1\'';
 
     /**
+    * Command to execute on Linux if only the names are needed.
+    */
+    public static readonly LINUX_COMMAND_NAMES_ONLY: string = 'df -P | awk \'NR > 1 {print $6}\'';
+
+    /**
      * Command to execute on OSX.
      */
     public static readonly DARWIN_COMMAND: string = 'df -P | awk \'NR > 1\'';
+
+    /**
+     * Command to execute on OSX if only the names are needed.
+     */
+    public static readonly DARWIN_COMMAND_NAMES_ONLY: string = 'df -P | awk \'NR > 1 {print $6}\'';
 
 }

--- a/test/linux.spec.ts
+++ b/test/linux.spec.ts
@@ -1,6 +1,8 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
-import {Utils} from '../src/utils/utils';
+import { getDiskInfo, getDiskInfoSync } from '../src';
+import { Utils } from '../src/utils/utils';
 import * as os from 'os';
+import { Constants } from '../src/utils/constants';
+import DiskInfoOptions from '../src/classes/options';
 
 describe('node-disk-info-linux', () => {
 
@@ -16,89 +18,170 @@ describe('node-disk-info-linux', () => {
         'tmpfs                  100       0       100       0% /var/lib/lxd/shmounts                                                                            \n' +
         'tmpfs                  100       0        bb       0% /var/lib/lxd/devlxd                                                                              \n' +
         '/dev/sdb          15728640 2088556  11919636      15% /var/lib/lxd/storage-pools/default                                                               \n', 'utf8');
+    const LINUX_COMMAND_RESPONSE_NAMES_ONLY: Buffer = Buffer.from('/                                                                                                \n' +
+        '/dev                                                                                             \n' +
+        '/dev/tty                                                                                         \n' +
+        '/dev/lxd                                                                                         \n' +
+        '/dev/.lxd-mounts                                                                                 \n' +
+        '/dev/shm                                                                                         \n' +
+        '/run                                                                                             \n' +
+        '/run/lock                                                                                        \n' +
+        '/sys/fs/cgroup                                                                                   \n' +
+        '/var/lib/lxd/shmounts                                                                            \n' +
+        '/var/lib/lxd/devlxd                                                                              \n' +
+        '/var/lib/lxd/storage-pools/default                                                               \n', 'utf8');
 
     beforeAll(() => {
         if (os.platform() !== 'linux') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'linux');
-            spyOn(Utils, 'execute').and.callFake((command: string) => LINUX_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake((param) => {
+                if (param === Constants.LINUX_COMMAND)
+                    return LINUX_COMMAND_RESPONSE;
+                else
+                    return LINUX_COMMAND_RESPONSE_NAMES_ONLY;
+            });
         }
     });
 
     it('should generate disks list info for Linux', (done) => {
-        getDiskInfo()
-            .then(values => {
+        Promise.all([getDiskInfo(), getDiskInfo(new DiskInfoOptions()), getDiskInfo(new DiskInfoOptions(false)), getDiskInfo(new DiskInfoOptions(true))])
+            .then((values) => {
                 expect(values).toBeDefined();
                 expect(values.length).toBeGreaterThanOrEqual(0);
+                expect(values.every(value => value.length > 0))
                 done();
             })
-            .catch(reason => {
+            .catch((reason) => {
                 done.fail(reason);
             });
     });
 
     it('should generate disk info for Linux', (done) => {
-        getDiskInfo()
-            .then(values => {
-                expect(values.length).toBeGreaterThan(0);
+        Promise.all([getDiskInfo(), getDiskInfo(new DiskInfoOptions()), getDiskInfo(new DiskInfoOptions(false))])
+            .then((vals) => {
+                vals.forEach(values => {
 
-                const disk = values[0];
 
-                expect(disk.filesystem).toBeDefined();
-                expect(typeof disk.filesystem).toEqual('string');
+                    expect(values.length).toBeGreaterThan(0);
 
-                expect(disk.blocks).toBeDefined();
-                expect(typeof disk.blocks).toEqual('number');
+                    const disk = values[0];
 
-                expect(disk.used).toBeDefined();
-                expect(typeof disk.used).toEqual('number');
+                    expect(disk.filesystem).toBeDefined();
+                    expect(typeof disk.filesystem).toEqual("string");
 
-                expect(disk.available).toBeDefined();
-                expect(typeof disk.available).toEqual('number');
+                    expect(disk.blocks).toBeDefined();
+                    expect(typeof disk.blocks).toEqual("number");
 
-                expect(disk.capacity).toBeDefined();
-                expect(typeof disk.capacity).toEqual('string');
+                    expect(disk.used).toBeDefined();
+                    expect(typeof disk.used).toEqual("number");
 
-                expect(disk.mounted).toBeDefined();
-                expect(typeof disk.mounted).toEqual('string');
+                    expect(disk.available).toBeDefined();
+                    expect(typeof disk.available).toEqual("number");
 
+                    expect(disk.capacity).toBeDefined();
+                    expect(typeof disk.capacity).toEqual("string");
+
+                    expect(disk.mounted).toBeDefined();
+                    expect(typeof disk.mounted).toEqual("string");
+                });
                 done();
             })
-            .catch(reason => {
+            .catch((reason) => {
+                done.fail(reason);
+            });
+    });
+
+    it('should generate disk info for Linux - name only', (done) => {
+        Promise.all([getDiskInfo(new DiskInfoOptions(true))])
+            .then((vals) => {
+                vals.forEach(values => {
+                    expect(values.length).toBeGreaterThan(0);
+
+                    const disk = values[0];
+
+                    expect(disk.filesystem).toBeDefined();
+                    expect(typeof disk.filesystem).toEqual("string");
+
+                    expect(disk.blocks).toBeDefined();
+                    expect(typeof disk.blocks).toEqual("number");
+
+                    expect(disk.used).toBeDefined();
+                    expect(typeof disk.used).toEqual("number");
+
+                    expect(disk.available).toBeDefined();
+                    expect(typeof disk.available).toEqual("number");
+
+                    expect(disk.capacity).toBeUndefined();
+                    expect(typeof disk.capacity).toEqual("undefined");
+
+                    expect(disk.mounted).toBeUndefined();
+                    expect(typeof disk.mounted).toEqual("undefined");
+                });
+                done();
+            })
+            .catch((reason) => {
                 done.fail(reason);
             });
     });
 
     it('should generate disks list info sync for Linux', () => {
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(false)), getDiskInfoSync(new DiskInfoOptions(true))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
 
     it('should generate disk info sync for Linux', () => {
-        const values = getDiskInfoSync();
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values.length).toBeGreaterThan(0);
 
-        expect(values.length).toBeGreaterThan(0);
+            const disk = values[0];
 
-        const disk = values[0];
+            expect(disk.filesystem).toBeDefined();
+            expect(typeof disk.filesystem).toEqual("string");
 
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
+            expect(disk.blocks).toBeDefined();
+            expect(typeof disk.blocks).toEqual("number");
 
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
+            expect(disk.used).toBeDefined();
+            expect(typeof disk.used).toEqual("number");
 
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
+            expect(disk.available).toBeDefined();
+            expect(typeof disk.available).toEqual("number");
 
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
+            expect(disk.capacity).toBeDefined();
+            expect(typeof disk.capacity).toEqual("string");
 
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
+            expect(disk.mounted).toBeDefined();
+            expect(typeof disk.mounted).toEqual("string");
+        });
     });
+    it('should generate disk info sync for Linux - names only', () => {
+        var results = [getDiskInfoSync(new DiskInfoOptions(true))]
+        results.forEach(values => {
+            expect(values.length).toBeGreaterThan(0);
 
+            const disk = values[0];
+
+            expect(disk.filesystem).toBeDefined();
+            expect(typeof disk.filesystem).toEqual("string");
+
+            expect(disk.blocks).toBeDefined();
+            expect(typeof disk.blocks).toEqual("number");
+
+            expect(disk.used).toBeDefined();
+            expect(typeof disk.used).toEqual("number");
+
+            expect(disk.available).toBeDefined();
+            expect(typeof disk.available).toEqual("number");
+
+            expect(disk.capacity).toBeUndefined();
+            expect(typeof disk.capacity).toEqual("undefined");
+
+            expect(disk.mounted).toBeUndefined();
+            expect(typeof disk.mounted).toEqual("undefined");
+        });
+    });
 });

--- a/test/win32.spec.ts
+++ b/test/win32.spec.ts
@@ -1,161 +1,196 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
-import {Utils} from '../src/utils/utils';
-import * as os from 'os';
+import { getDiskInfo, getDiskInfoSync } from "../src";
+import { Utils } from "../src/utils/utils";
+import * as os from "os";
+import DiskInfoOptions from "../src/classes/options";
+import { Constants } from "../src/utils/constants";
+describe("node-disk-info-win32", () => {
+    const WINDOWS_COMMAND_RESPONSE: Buffer = Buffer.from(
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=C:\r\r\n" +
+        "Description=Disco fijo local\r\r\n" +
+        "FreeSpace=3771858944\r\r\n" +
+        "Size=119387713536\r\r\n" +
+        "VolumeSerialNumber=2ADAE52C\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=D:\r\r\n" +
+        "Description=Disco fijo local\r\r\n" +
+        "FreeSpace=17136254976\r\r\n" +
+        "Size=925015994368\r\r\n" +
+        "VolumeSerialNumber=5140A8B0\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=E:\r\r\n" +
+        "Description=Disco CD-ROM\r\r\n" +
+        "FreeSpace=\r\r\n" +
+        "Size=\r\r\n" +
+        "VolumeSerialNumber=\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n",
+        "utf8"
+    );
 
-describe('node-disk-info-win32', () => {
-
-    const WINDOWS_COMMAND_RESPONSE: Buffer = Buffer.from('\r\r\n' +
-        '\r\r\n' +
-        'Caption=C:\r\r\n' +
-        'Description=Disco fijo local\r\r\n' +
-        'FreeSpace=3771858944\r\r\n' +
-        'Size=119387713536\r\r\n' +
-        'VolumeSerialNumber=2ADAE52C\r\r\n' +
-        '\r\r\n' +
-        '\r\r\n' +
-        'Caption=D:\r\r\n' +
-        'Description=Disco fijo local\r\r\n' +
-        'FreeSpace=17136254976\r\r\n' +
-        'Size=925015994368\r\r\n' +
-        'VolumeSerialNumber=5140A8B0\r\r\n' +
-        '\r\r\n' +
-        '\r\r\n' +
-        'Caption=E:\r\r\n' +
-        'Description=Disco CD-ROM\r\r\n' +
-        'FreeSpace=\r\r\n' +
-        'Size=\r\r\n' +
-        'VolumeSerialNumber=\r\r\n' +
-        '\r\r\n' +
-        '\r\r\n' +
-        '\r\r\n', 'utf8');
+    const WINDOWS_COMMAND_RESPONSE_NAMES_ONLY: Buffer = Buffer.from(
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=C:\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=D:\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n" +
+        "Caption=E:\r\r\n" +
+        "\r\r\n" +
+        "\r\r\n",
+        "utf8"
+    );
 
     beforeAll(() => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'detectPlatform').and.callFake(() => 'win32');
-            spyOn(Utils, 'execute').and.callFake(() => WINDOWS_COMMAND_RESPONSE);
+        if (os.platform() !== "win32") {
+            spyOn(Utils, "detectPlatform").and.callFake(() => "win32");
         }
+        spyOn(Utils, "execute").and.callFake((param) => {
+            if (param === Constants.WINDOWS_COMMAND)
+                return WINDOWS_COMMAND_RESPONSE;
+            else
+                return WINDOWS_COMMAND_RESPONSE_NAMES_ONLY;
+        });
+
     });
 
-    it('should generate disks list info for Windows', (done) => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
+    it("should generate disks list info for Windows", (done) => {
+        if (os.platform() !== "win32") {
+            spyOn(Utils, "chcp").and.callFake(() => "65001");
         }
-        getDiskInfo()
-            .then(values => {
+        Promise.all([getDiskInfo(), getDiskInfo(new DiskInfoOptions()), getDiskInfo(new DiskInfoOptions(true)), getDiskInfo(new DiskInfoOptions(false))])
+            .then((values) => {
                 expect(values).toBeDefined();
                 expect(values.length).toBeGreaterThanOrEqual(0);
-
+                expect(values.every(value => value.length > 0))
                 done();
             })
-            .catch(reason => {
+            .catch((reason) => {
+                done.fail(reason);
+            });
+
+
+
+    });
+
+    it("should generate disk info for Windows", (done) => {
+        if (os.platform() !== "win32") {
+            spyOn(Utils, "chcp").and.callFake(() => "65001");
+        }
+        Promise.all([getDiskInfo(), getDiskInfo(new DiskInfoOptions()), getDiskInfo(new DiskInfoOptions(true)), getDiskInfo(new DiskInfoOptions(false))])
+            .then((vals) => {
+                vals.forEach(values => {
+
+
+                    expect(values.length).toBeGreaterThan(0);
+
+                    const disk = values[0];
+
+                    expect(disk.filesystem).toBeDefined();
+                    expect(typeof disk.filesystem).toEqual("string");
+
+                    expect(disk.blocks).toBeDefined();
+                    expect(typeof disk.blocks).toEqual("number");
+
+                    expect(disk.used).toBeDefined();
+                    expect(typeof disk.used).toEqual("number");
+
+                    expect(disk.available).toBeDefined();
+                    expect(typeof disk.available).toEqual("number");
+
+                    expect(disk.capacity).toBeDefined();
+                    expect(typeof disk.capacity).toEqual("string");
+
+                    expect(disk.mounted).toBeDefined();
+                    expect(typeof disk.mounted).toEqual("string");
+                });
+                done();
+            })
+            .catch((reason) => {
                 done.fail(reason);
             });
     });
 
-    it('should generate disk info for Windows', (done) => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
+    it("should generate disks list info sync for Windows", () => {
+        if (os.platform() !== "win32") {
+            spyOn(Utils, "chcp").and.callFake(() => "65001");
         }
-        getDiskInfo()
-            .then(values => {
-                expect(values.length).toBeGreaterThan(0);
-
-                const disk = values[0];
-
-                expect(disk.filesystem).toBeDefined();
-                expect(typeof disk.filesystem).toEqual('string');
-
-                expect(disk.blocks).toBeDefined();
-                expect(typeof disk.blocks).toEqual('number');
-
-                expect(disk.used).toBeDefined();
-                expect(typeof disk.used).toEqual('number');
-
-                expect(disk.available).toBeDefined();
-                expect(typeof disk.available).toEqual('number');
-
-                expect(disk.capacity).toBeDefined();
-                expect(typeof disk.capacity).toEqual('string');
-
-                expect(disk.mounted).toBeDefined();
-                expect(typeof disk.mounted).toEqual('string');
-
-                done();
-            })
-            .catch(reason => {
-                done.fail(reason);
-            });
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
 
-    it('should generate disks list info sync for Windows', () => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
+    it("should generate disk info sync for Windows", () => {
+        if (os.platform() !== "win32") {
+            spyOn(Utils, "chcp").and.callFake(() => "65001");
         }
-        const values = getDiskInfoSync();
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values.length).toBeGreaterThan(0);
 
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
+            const disk = values[0];
+
+            expect(disk.filesystem).toBeDefined();
+            expect(typeof disk.filesystem).toEqual("string");
+
+            expect(disk.blocks).toBeDefined();
+            expect(typeof disk.blocks).toEqual("number");
+
+            expect(disk.used).toBeDefined();
+            expect(typeof disk.used).toEqual("number");
+
+            expect(disk.available).toBeDefined();
+            expect(typeof disk.available).toEqual("number");
+
+            expect(disk.capacity).toBeDefined();
+            expect(typeof disk.capacity).toEqual("string");
+
+            expect(disk.mounted).toBeDefined();
+            expect(typeof disk.mounted).toEqual("string");
+        });
     });
 
-    it('should generate disk info sync for Windows', () => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
-        }
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
+    it("should generate disks list info sync for Windows chcp 65000", () => {
+        spyOn(Utils, "chcp").and.callFake(() => "65000");
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
 
-    it('should generate disks list info sync for Windows chcp 65000', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '65000');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
+    it("should generate disks list info sync for Windows chcp 65001", () => {
+        spyOn(Utils, "chcp").and.callFake(() => "65001");
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
 
-    it('should generate disks list info sync for Windows chcp 65001', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '65001');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
+    it("should generate disks list info sync for Windows chcp ascii", () => {
+        spyOn(Utils, "chcp").and.callFake(() => "ascii");
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
 
-    it('should generate disks list info sync for Windows chcp ascii', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => 'ascii');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
+    it("should generate disks list info sync for Windows chcp 1252", () => {
+        spyOn(Utils, "chcp").and.callFake(() => "1252");
+        var results = [getDiskInfoSync(), getDiskInfoSync(new DiskInfoOptions()), getDiskInfoSync(new DiskInfoOptions(true)), getDiskInfoSync(new DiskInfoOptions(false))]
+        results.forEach(values => {
+            expect(values).toBeDefined();
+            expect(values.length).toBeGreaterThanOrEqual(0);
+        });
     });
-
-    it('should generate disks list info sync for Windows chcp 1252', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '1252');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
 });


### PR DESCRIPTION
Hi,

On Windows System discovery of the complete disk information may be very slow, especially on network mapped drives. Therfore I added an options object that allows to only query the names of the disks instead of the full information which is enormously faster and may be enough for the user.

I made the Options  optional :) so this should not be a breaking change. If you have any Ideas on how to improve on this Ill be glad to help