### PR TITLE
Fixed: mountpoints containing spaces were truncated (Linux/Darwin)

### DIFF
--- a/dist/platforms/darwin.js
+++ b/dist/platforms/darwin.js
@@ -26,7 +26,7 @@ var Darwin = /** @class */ (function () {
             if (value !== '') {
                 var line = value.replace(/ +(?= )/g, '');
                 var tokens = line.split(' ');
-                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens[5]);
+                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
                 drives.push(d);
             }
         });

--- a/dist/platforms/linux.js
+++ b/dist/platforms/linux.js
@@ -26,7 +26,7 @@ var Linux = /** @class */ (function () {
             if (value !== '') {
                 var line = value.replace(/ +(?= )/g, '');
                 var tokens = line.split(' ');
-                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens[5]);
+                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
                 drives.push(d);
             }
         });

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -22,7 +22,6 @@ export class Darwin {
         lines.forEach((value, index, array) => {
 
             if (value !== '') {
-
                 const line: string = value.replace(/ +(?= )/g, '');
                 const tokens = line.split(' ');
 
@@ -32,7 +31,7 @@ export class Darwin {
                     isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2],
                     isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3],
                     tokens[4],
-                    tokens[5]);
+                    tokens.slice(5).join(' '));
 
                 drives.push(d);
 

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -32,7 +32,7 @@ export class Linux {
                     isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2],
                     isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3],
                     tokens[4],
-                    tokens[5]);
+                    tokens.slice(5).join(' '));
 
                 drives.push(d);
             }


### PR DESCRIPTION
`/Volumes/ReactExplorer 2.3.1` would be listed as `/Volumes/ReactExplorer` instead.